### PR TITLE
Allowlist CKD_*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-bindings"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Dana Keeler <dkeeler@mozilla.com>", "John Schanck <jschanck@mozilla.com>"]
 license = "MIT"
 description = "Rust bindings for the PKCS#11 specification"

--- a/build.rs
+++ b/build.rs
@@ -82,6 +82,7 @@ fn main() {
         .allowlist_var("CK_INVALID_HANDLE")
         .allowlist_var("CKA_.*")
         .allowlist_var("CKC_.*")
+        .allowlist_var("CKD_.*")
         .allowlist_var("CKF_.*")
         .allowlist_var("CKK_.*")
         .allowlist_var("CKM_.*")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(overflowing_literals)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// Constants from NSS [pkcs11n.h](https://hg.mozilla.org/projects/nss/file/tip/lib/util/pkcs11n.h)


### PR DESCRIPTION
I want to remove the PKCS#11 definitions from `nss-gk-api`, and we use `CKD_NULL` there.