### PR TITLE
Allow a wider range of bindgen versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-bindings"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Dana Keeler <dkeeler@mozilla.com>", "John Schanck <jschanck@mozilla.com>"]
 license = "MIT"
 description = "Rust bindings for the PKCS#11 specification"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-bindgen = { default-features = false, features = ["runtime"], version = "0.61" }
+bindgen = { default-features = false, features = ["runtime"], version = ">= 0.59.2" }

--- a/build.rs
+++ b/build.rs
@@ -12,56 +12,12 @@ use std::path::PathBuf;
 struct PKCS11TypesParseCallbacks;
 
 impl ParseCallbacks for PKCS11TypesParseCallbacks {
-    fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
-        MacroParsingBehavior::Default
-    }
-
     fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
         if name == "CK_TRUE" || name == "CK_FALSE" {
             Some(IntKind::U8)
         } else {
             Some(IntKind::ULong)
         }
-    }
-
-    fn str_macro(&self, _name: &str, _value: &[u8]) {}
-
-    fn func_macro(&self, _name: &str, _value: &[&[u8]]) {}
-
-    fn enum_variant_behavior(
-        &self,
-        _enum_name: Option<&str>,
-        _original_variant_name: &str,
-        _variant_value: EnumVariantValue,
-    ) -> Option<EnumVariantCustomBehavior> {
-        None
-    }
-
-    fn enum_variant_name(
-        &self,
-        _enum_name: Option<&str>,
-        _original_variant_name: &str,
-        _variant_value: EnumVariantValue,
-    ) -> Option<String> {
-        None
-    }
-
-    fn item_name(&self, _original_item_name: &str) -> Option<String> {
-        None
-    }
-
-    fn include_file(&self, _filename: &str) {}
-
-    fn blocklisted_type_implements_trait(
-        &self,
-        _name: &str,
-        _derive_trait: DeriveTrait,
-    ) -> Option<ImplementsTrait> {
-        None
-    }
-
-    fn add_derives(&self, _name: &str) -> Vec<String> {
-        Vec::new()
     }
 }
 


### PR DESCRIPTION
Our implementation of `ParseCallbacks` in build.rs was incompatible with bindgen 0.63 because of a change to the signature of `ParseCallbacks::add_derives`. We can preserve compat with bindgen 0.59.2 through 0.63 by removing our implementation (which was identical to the default).

I've also changed to specifying the minimum supported bindgen version in Cargo.toml using the ">=" syntax. This should make it easier to vendor this crate into M-C.