### PR TITLE
Dont use newest bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-bindgen = { default-features = false, features = ["runtime"], version = ">= 0.59.2" }
+bindgen = { default-features = false, features = ["runtime"], version = "0.59.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 edition = "2018"
 
 [build-dependencies]
-bindgen = { default-features = false, features = ["runtime"], version = "0.59.2" }
+bindgen = { default-features = false, features = ["runtime"], version = ">= 0.59.2, < 0.70" }


### PR DESCRIPTION
auth-rs is currently failing in CI.
The reason is that the latest bindgen-release had a breaking change. It now uses `std::mem::offset_of()`, which has only been added to stable Rust with version 1.77 (see https://github.com/rust-lang/rust-bindgen/issues/2960)

We are using an older version of Rust to build auth-rs. So let's use a version-range of bindgen that does not use this function.

This is the least intrusive fix. We could also make it work with the most recent bindgen-version, by using `rust_target(RustTarget::Stable_1_73)` when creating the bindings. Let me know, if I should do that instead.

The same has to be done for `nss-gk-api`. I can do that, but this crate would need a new version released first.